### PR TITLE
Elementary: Upgrade dbt package.

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: calogica/dbt_expectations
     version: 0.10.3
   - package: elementary-data/elementary
-    version: 0.15.2
+    version: 0.16.1


### PR DESCRIPTION

**Elementary**: This PR upgrades Elementary's dbt package version to the latest.
We recommend upgrading in order to enjoy the latest features, performance improvements, and bug fixes.
You can view the release notes [here](https://github.com/elementary-data/dbt-data-reliability/releases).
